### PR TITLE
Link lblod ID to WebID in the API database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY --chown=worker:worker requirements.txt .
 RUN pip install --user -r requirements.txt
 
 
-COPY --chown=worker:worker src/ .
+COPY --chown=worker:worker src/ app/
 
-CMD ["python", "main.py"]
+CMD ["python", "app/main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - 8000:8000
     volumes:
-      - ./src:/usr/src/app
+      - ./src:/home/worker/app
     environment:
       - DEBUG=${DEBUG}
       - PG_HOST=${PG_HOST}

--- a/src/helper_sparql.py
+++ b/src/helper_sparql.py
@@ -1,0 +1,24 @@
+import requests
+from os import environ
+
+
+def lblod_id_exists(lblod_id):
+    sparql_url = environ.get('SPARQL_URL')
+
+    query = """
+    PREFIX ams: <http://www.w3.org/ns/adms#>
+    SELECT DISTINCT ?id
+    WHERE {
+        ?id ams:identifier <%s>.
+    }""" % (lblod_id)
+    res = requests.get(
+            sparql_url,
+            params={
+                "default-graph-uri": "http://api.sep.osoc.be/mandatendatabank",
+                "format": "json",
+                "query": query
+            }
+        )
+
+    results = res.json()['results']['bindings']
+    return bool(results)

--- a/src/main.py
+++ b/src/main.py
@@ -22,13 +22,13 @@ CORS(app)
 @app.route('/store/', methods=['POST'])
 @doc.summary("store a new web id")
 async def r_store(req):\
-    # Get 'uri' and 'lblod_id' from JSON body and throw HTTP/400 if one of them is missing
+        # Get 'uri' and 'lblod_id' from JSON body and throw HTTP/400 if one of them is missing
     uri = req.json.get('uri')
-    lblod_id = req.get('lblod_id')
+    lblod_id = req.json.get('lblod_id')
     if not uri or not lblod_id:
         return response.json({'success': False, 'message': 'Please set the "uri" and "lblod_id" fields in your JSON body'}, status=400)
 
-    if not helper_sparql.lblod_id_exists():
+    if not helper_sparql.lblod_id_exists(lblod_id):
         return response.json({'success': False, 'message': 'This lblod ID does not exist in our dataset'}, status=400)
 
     # Try to add the data to the database, throw HTTP/400 if user tries to add an existing value
@@ -97,13 +97,13 @@ async def get_handler(req):
             foaf:familyName ?familyName .
     }"""
     query_response = requests.get(
-            sparql_url,
-            params={
-                "default-graph-uri": "http://api.sep.osoc.be/mandatendatabank",
-                "format": "json",
-                "query": query
-            }
-        )
+        sparql_url,
+        params={
+            "default-graph-uri": "http://api.sep.osoc.be/mandatendatabank",
+            "format": "json",
+            "query": query
+        }
+    )
     json_response = json.loads(
         query_response.content.decode('utf-8')
     )
@@ -113,9 +113,11 @@ async def get_handler(req):
 def get_web_ids():
     web_ids = models.WebID.select()
 
-    web_ids = [model_to_dict(web_id) for web_id in web_ids]  # Convert list of ModelSelect objects to Python dicts
+    # Convert list of ModelSelect objects to Python dicts
+    web_ids = [model_to_dict(web_id) for web_id in web_ids]
     for web_id in web_ids:
-        web_id['date_created'] = web_id['date_created'].isoformat()  # Convert Python datetime object to ISO 8601 string
+        # Convert Python datetime object to ISO 8601 string
+        web_id['date_created'] = web_id['date_created'].isoformat()
 
     return web_ids
 
@@ -126,5 +128,6 @@ def check_equal_names(name1, name2):
 
 
 if __name__ == '__main__':
-    models.db.create_tables([models.WebID])  # Connect to database & create tables if necessary
+    # Connect to database & create tables if necessary
+    models.db.create_tables([models.WebID])
     app.run(host='0.0.0.0', port=8000, debug=environ.get('DEBUG'))

--- a/src/main.py
+++ b/src/main.py
@@ -21,12 +21,13 @@ CORS(app)
 @doc.summary("store a new web id")
 async def r_store(req):
     uri = req.json['uri']
-    web_id = models.WebID(uri=uri)
+    lblod_id = req.json['lblod_id']
+    web_id = models.WebID(uri=uri, lblod_id=lblod_id)
 
     try:
         web_id.save()
     except IntegrityError:  # Thrown when you try to add an existing unique value
-        return response.json({'success': False, 'message': 'WebID already exists in database'}, status=400)
+        return response.json({'success': False, 'message': 'WebID or lblod ID already exists in database'}, status=400)
 
     return response.json({'success': True, 'message': 'WebID succesfully added to the database!'})
 

--- a/src/models.py
+++ b/src/models.py
@@ -24,4 +24,5 @@ class BaseModel(Model):
 
 class WebID(BaseModel):
     uri = CharField(unique=True)
+    lblod_id = CharField(unique=True)
     date_created = DateTimeField(default=datetime.datetime.now)


### PR DESCRIPTION
Right now this has to be manually linked in the declaration form. We tried to match the IDs with the names from the lblod dataset, but there are duplicate names and we don't have another usable unique identifier. One option would be to use the candidate's social security number (BSN), but our current dataset does not contain this data for obvious reasons.