### PR TITLE
Add middleware to automatically open/close a database connection for every request

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -19,6 +19,18 @@ app.config["API_DESCRIPTION"] = "API documentation of the Solid Elections API"
 CORS(app)
 
 
+# Middleware to automatically open/close a database connection for every request
+@app.middleware('request')
+async def handle_request(request):
+    models.db.connect()
+
+@app.middleware('response')
+async def handle_response(request, response):
+    if not models.db.is_closed():
+        models.db.close()
+
+
+
 @app.route('/store/', methods=['POST'])
 @doc.summary("store a new web id")
 async def r_store(req):\
@@ -186,4 +198,5 @@ def check_equal_names(name1, name2):
 if __name__ == '__main__':
     # Connect to database & create tables if necessary
     models.db.create_tables([models.WebID])
+    models.db.close()
     app.run(host='0.0.0.0', port=8000, debug=environ.get('DEBUG'))

--- a/src/models.py
+++ b/src/models.py
@@ -1,19 +1,15 @@
 from peewee import Model, PostgresqlDatabase, CharField, DateTimeField
-from playhouse.shortcuts import ReconnectMixin
 import datetime
 
 from os import environ
 
-
-class ReconnectPostgresqlDatabase(ReconnectMixin, PostgresqlDatabase):
-    pass
-
-
-db = ReconnectPostgresqlDatabase(host=environ.get('PG_HOST'),
-                                 database=environ.get('PG_DBNAME'),
-                                 user=environ.get('PG_USER'),
-                                 password=environ.get('PG_PASS'),
-                                 autorollback=True)
+# TODO: peewee's docs mention a middleware thing for sanic, but it seems to want to reconnect to the database for every request? Maybe check it out
+# http://docs.peewee-orm.com/en/latest/peewee/database.html#sanic
+db = PostgresqlDatabase(host=environ.get('PG_HOST'),
+                        database=environ.get('PG_DBNAME'),
+                        user=environ.get('PG_USER'),
+                        password=environ.get('PG_PASS'),
+                        autorollback=True)
 
 # NOTE: peewee unfortunately does not support automatic schema migrations, so we have to handle this manually if we change a model.
 # Fortunately the data we're storing is pretty simple, so this shouldn't happen a lot.


### PR DESCRIPTION
This might cause problems with a *lot* of requests, but I tried it on my local machine with a bunch of parallel requests running and it seems to work fine.

(hopefully) fixes #22